### PR TITLE
feat: adds support to group logs of the same http request

### DIFF
--- a/src/main/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancer.java
+++ b/src/main/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancer.java
@@ -20,8 +20,9 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.cloud.logging.LogEntry;
 import org.slf4j.MDC;
 
-/* Adds support for grouping logs by incoming http request
- *  */
+/** Adds support for grouping logs by incoming http request
+ *
+ */
 public class TraceLoggingEventEnhancer implements LoggingEventEnhancer {
 
   // A key used by Cloud Logging for trace Id

--- a/src/main/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancer.java
+++ b/src/main/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging.logback;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.google.cloud.logging.LogEntry;
+import org.slf4j.MDC;
+
+/* Adds support for grouping logs by incoming http request
+*  */
+public class TraceLoggingEventEnhancer implements LoggingEventEnhancer {
+
+    // A key used by Cloud Logging for trace Id
+    private static final String TRACE_ID = "logging.googleapis.trace";
+
+    /**
+     * Set the Trace ID associated with any logging done by the current thread.
+     *
+     * @param id The traceID, in the form projects/[PROJECT_ID]/traces/[TRACE_ID]
+     */
+    public static void setCurrentTraceId(String id) {
+        MDC.put(TRACE_ID, id);
+    }
+
+    /**
+     * Get the Trace ID associated with any logging done by the current thread.
+     *
+     * @return id The traceID
+     */
+    public static String getCurrentTraceId() {
+        return MDC.get(TRACE_ID);
+    }
+
+
+    @Override
+    public void enhanceLogEntry(LogEntry.Builder builder, ILoggingEvent e) {
+        String traceId = e.getMDCPropertyMap().getOrDefault(TRACE_ID, null);
+        if (traceId != null) {
+            builder.setTrace(traceId);
+        }
+    }
+}

--- a/src/main/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancer.java
+++ b/src/main/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancer.java
@@ -20,9 +20,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.cloud.logging.LogEntry;
 import org.slf4j.MDC;
 
-/** Adds support for grouping logs by incoming http request
- *
- */
+/** Adds support for grouping logs by incoming http request */
 public class TraceLoggingEventEnhancer implements LoggingEventEnhancer {
 
   // A key used by Cloud Logging for trace Id

--- a/src/main/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancer.java
+++ b/src/main/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancer.java
@@ -21,36 +21,36 @@ import com.google.cloud.logging.LogEntry;
 import org.slf4j.MDC;
 
 /* Adds support for grouping logs by incoming http request
-*  */
+ *  */
 public class TraceLoggingEventEnhancer implements LoggingEventEnhancer {
 
-    // A key used by Cloud Logging for trace Id
-    private static final String TRACE_ID = "logging.googleapis.trace";
+  // A key used by Cloud Logging for trace Id
+  private static final String TRACE_ID = "logging.googleapis.trace";
 
-    /**
-     * Set the Trace ID associated with any logging done by the current thread.
-     *
-     * @param id The traceID, in the form projects/[PROJECT_ID]/traces/[TRACE_ID]
-     */
-    public static void setCurrentTraceId(String id) {
-        MDC.put(TRACE_ID, id);
+  /**
+   * Set the Trace ID associated with any logging done by the current thread.
+   *
+   * @param id The traceID, in the form projects/[PROJECT_ID]/traces/[TRACE_ID]
+   */
+  public static void setCurrentTraceId(String id) {
+    MDC.put(TRACE_ID, id);
+  }
+
+  /**
+   * Get the Trace ID associated with any logging done by the current thread.
+   *
+   * @return id The traceID
+   */
+  public static String getCurrentTraceId() {
+    return MDC.get(TRACE_ID);
+  }
+
+  @Override
+  public void enhanceLogEntry(LogEntry.Builder builder, ILoggingEvent e) {
+    Object value = e.getMDCPropertyMap().get(TRACE_ID);
+    String traceId = value != null ? value.toString() : null;
+    if (traceId != null) {
+      builder.setTrace(traceId);
     }
-
-    /**
-     * Get the Trace ID associated with any logging done by the current thread.
-     *
-     * @return id The traceID
-     */
-    public static String getCurrentTraceId() {
-        return MDC.get(TRACE_ID);
-    }
-
-
-    @Override
-    public void enhanceLogEntry(LogEntry.Builder builder, ILoggingEvent e) {
-        String traceId = e.getMDCPropertyMap().getOrDefault(TRACE_ID, null);
-        if (traceId != null) {
-            builder.setTrace(traceId);
-        }
-    }
+  }
 }

--- a/src/test/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancerTest.java
+++ b/src/test/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancerTest.java
@@ -25,40 +25,40 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TraceLoggingEventEnhancerTest {
-    private TraceLoggingEventEnhancer classUnderTest;
+  private TraceLoggingEventEnhancer classUnderTest;
 
-    @Before
-    public void setUp() {
-        classUnderTest = new TraceLoggingEventEnhancer();
-    }
+  @Before
+  public void setUp() {
+    classUnderTest = new TraceLoggingEventEnhancer();
+  }
 
-    @Test
-    public void testEnhanceLogEntry() {
-        // setup
-        String traceId = "abc";
-        TraceLoggingEventEnhancer.setCurrentTraceId(traceId);
-        LoggingEvent loggingEvent = new LoggingEvent();
-        loggingEvent.setMessage("this is a test");
-        LogEntry.Builder builder = LogEntry.newBuilder(StringPayload.of("this is a test"));
+  @Test
+  public void testEnhanceLogEntry() {
+    // setup
+    String traceId = "abc";
+    TraceLoggingEventEnhancer.setCurrentTraceId(traceId);
+    LoggingEvent loggingEvent = new LoggingEvent();
+    loggingEvent.setMessage("this is a test");
+    LogEntry.Builder builder = LogEntry.newBuilder(StringPayload.of("this is a test"));
 
-        // act
-        classUnderTest.enhanceLogEntry(builder, loggingEvent);
-        LogEntry logEntry = builder.build();
+    // act
+    classUnderTest.enhanceLogEntry(builder, loggingEvent);
+    LogEntry logEntry = builder.build();
 
-        // assert - Trace Id should be recorded as explicit Trace field, not as a label
-        assertThat(traceId.equalsIgnoreCase(logEntry.getTrace()));
-    }
+    // assert - Trace Id should be recorded as explicit Trace field, not as a label
+    assertThat(traceId.equalsIgnoreCase(logEntry.getTrace()));
+  }
 
-    @Test
-    public void testGetCurrentTraceId() {
-        // setup
-        String traceId = "abc";
-        TraceLoggingEventEnhancer.setCurrentTraceId(traceId);
+  @Test
+  public void testGetCurrentTraceId() {
+    // setup
+    String traceId = "abc";
+    TraceLoggingEventEnhancer.setCurrentTraceId(traceId);
 
-        // act
-        String currentTraceId = TraceLoggingEventEnhancer.getCurrentTraceId();
+    // act
+    String currentTraceId = TraceLoggingEventEnhancer.getCurrentTraceId();
 
-        // assert
-        assertThat(traceId.equalsIgnoreCase(currentTraceId));
-    }
+    // assert
+    assertThat(traceId.equalsIgnoreCase(currentTraceId));
+  }
 }

--- a/src/test/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancerTest.java
+++ b/src/test/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging.logback;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import ch.qos.logback.classic.spi.LoggingEvent;
+import com.google.cloud.logging.LogEntry;
+import com.google.cloud.logging.Payload.StringPayload;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TraceLoggingEventEnhancerTest {
+    private TraceLoggingEventEnhancer classUnderTest;
+
+    @Before
+    public void setUp() {
+        classUnderTest = new TraceLoggingEventEnhancer();
+    }
+
+    @Test
+    public void testEnhanceLogEntry() {
+        // setup
+        String traceId = "abc";
+        TraceLoggingEventEnhancer.setCurrentTraceId(traceId);
+        LoggingEvent loggingEvent = new LoggingEvent();
+        loggingEvent.setMessage("this is a test");
+        LogEntry.Builder builder = LogEntry.newBuilder(StringPayload.of("this is a test"));
+
+        // act
+        classUnderTest.enhanceLogEntry(builder, loggingEvent);
+        LogEntry logEntry = builder.build();
+
+        // assert - Trace Id should be recorded as explicit Trace field, not as a label
+        assertThat(traceId.equalsIgnoreCase(logEntry.getTrace()));
+    }
+
+    @Test
+    public void testGetCurrentTraceId() {
+        // setup
+        String traceId = "abc";
+        TraceLoggingEventEnhancer.setCurrentTraceId(traceId);
+
+        // act
+        String currentTraceId = TraceLoggingEventEnhancer.getCurrentTraceId();
+
+        // assert
+        assertThat(traceId.equalsIgnoreCase(currentTraceId));
+    }
+}


### PR DESCRIPTION
With TraceLoggingEventEnhancer users can set the traceId of the incoming request and then all the logs that will be created on the same thread will have the traceId property set to that traceId. This allows Cloud Logging to group log entries from the same request in the UI for easier troubleshooting.

Example:

User's code (when receiving http request):
```java
TraceLoggingEnhancer.setCurrentTraceId(
      "projects/" + GOOGLE_PROJECT_ID + "/traces/" + traceId);
```
Then just logging regularly:
```java
LOGGER.info("XXX");
```
Then use grouping by traceId in Cloud Logging:
![image](https://user-images.githubusercontent.com/32641282/101214331-b8b2fc80-3630-11eb-9526-7d68c599a68d.png)


- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-logging-logback/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #94 ☕️
