### PR TITLE
fix: Add cleanup for  Trace context

### DIFF
--- a/src/main/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancer.java
+++ b/src/main/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancer.java
@@ -31,10 +31,15 @@ public class TraceLoggingEventEnhancer implements LoggingEventEnhancer {
    *
    * @param id The traceID, in the form projects/[PROJECT_ID]/traces/[TRACE_ID]
    */
-  public static void setCurrentTraceId(String id) {
-    MDC.put(TRACE_ID, id);
-  }
+  public static void setCurrentTraceId(String id) { MDC.put(TRACE_ID, id); }
 
+  /**
+   * Clearing a trace Id from the MDC
+   *
+   */
+   public static void clearTraceId() {
+    MDC.remove(TRACE_ID);
+  }
   /**
    * Get the Trace ID associated with any logging done by the current thread.
    *

--- a/src/main/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancer.java
+++ b/src/main/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancer.java
@@ -31,13 +31,12 @@ public class TraceLoggingEventEnhancer implements LoggingEventEnhancer {
    *
    * @param id The traceID, in the form projects/[PROJECT_ID]/traces/[TRACE_ID]
    */
-  public static void setCurrentTraceId(String id) { MDC.put(TRACE_ID, id); }
+  public static void setCurrentTraceId(String id) {
+    MDC.put(TRACE_ID, id);
+  }
 
-  /**
-   * Clearing a trace Id from the MDC
-   *
-   */
-   public static void clearTraceId() {
+  /** Clearing a trace Id from the MDC */
+  public static void clearTraceId() {
     MDC.remove(TRACE_ID);
   }
   /**

--- a/src/test/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancerTest.java
+++ b/src/test/java/com/google/cloud/logging/logback/TraceLoggingEventEnhancerTest.java
@@ -21,6 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Payload.StringPayload;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,6 +31,11 @@ public class TraceLoggingEventEnhancerTest {
   @Before
   public void setUp() {
     classUnderTest = new TraceLoggingEventEnhancer();
+  }
+
+  @After
+  public void tearDown() {
+    TraceLoggingEventEnhancer.clearTraceId();
   }
 
   @Test


### PR DESCRIPTION
Added cleanup of trace context before each test execution of tests that set it. This prevents side effects for other tests as a result of random ordering in junit.

Fixes #265 ☕️
Fixes #264 ☕️
Fixes #263 ☕️