### PR TITLE
feat: allow flush level OFF

### DIFF
--- a/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
+++ b/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
@@ -211,7 +211,10 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     MonitoredResource resource = getMonitoredResource(getProjectId());
     defaultWriteOptions =
         new WriteOption[] {WriteOption.logName(getLogName()), WriteOption.resource(resource)};
-    getLogging().setFlushSeverity(severityFor(getFlushLevel()));
+    Level flushLevel = getFlushLevel();
+    if (flushLevel != Level.OFF) {
+        getLogging().setFlushSeverity(severityFor(flushLevel));
+    }
     loggingEnhancers = new ArrayList<>();
     List<LoggingEnhancer> resourceEnhancers = MonitoredResourceUtil.getResourceEnhancers();
     loggingEnhancers.addAll(resourceEnhancers);

--- a/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
+++ b/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
@@ -213,7 +213,7 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         new WriteOption[] {WriteOption.logName(getLogName()), WriteOption.resource(resource)};
     Level flushLevel = getFlushLevel();
     if (flushLevel != Level.OFF) {
-        getLogging().setFlushSeverity(severityFor(flushLevel));
+      getLogging().setFlushSeverity(severityFor(flushLevel));
     }
     loggingEnhancers = new ArrayList<>();
     List<LoggingEnhancer> resourceEnhancers = MonitoredResourceUtil.getResourceEnhancers();

--- a/src/test/java/com/google/cloud/logging/logback/LoggingAppenderTest.java
+++ b/src/test/java/com/google/cloud/logging/logback/LoggingAppenderTest.java
@@ -117,7 +117,7 @@ public class LoggingAppenderTest {
     loggingAppender.setFlushLevel(Level.OFF);
     loggingAppender.start();
     Severity foundSeverity = logging.getFlushSeverity();
-    assertThat(null, is(foundSeverity));
+    assertThat(foundSeverity).isEqualTo(null);
   }
 
   @Test

--- a/src/test/java/com/google/cloud/logging/logback/LoggingAppenderTest.java
+++ b/src/test/java/com/google/cloud/logging/logback/LoggingAppenderTest.java
@@ -113,6 +113,14 @@ public class LoggingAppenderTest {
   }
 
   @Test
+  public void testFlushLevelConfigSupportsFlushLevelOff() {
+    loggingAppender.setFlushLevel(Level.OFF);
+    loggingAppender.start();
+    Severity foundSeverity = logging.getFlushSeverity();
+    assertThat(null, is(foundSeverity));
+  }
+
+  @Test
   public void testFilterLogsOnlyLogsAtOrAboveLogLevel() {
     Map<String, Object> jsonContent = new HashMap<>();
     jsonContent.put("message", "this is a test");


### PR DESCRIPTION
The library takes in a FlushLevel argument, which defaults to ERROR. Any logs at that level or higher will be auto-flushed instead of batched.

It appears there is no way to turn the flush level off, forcing all logs to be batched. This PR checks for Level.OFF, and doesn't set the flush level if it is chosen

Fixes https://github.com/googleapis/java-logging-logback/issues/133 ☕️
