### PR TITLE
Expose projectId via LoggingOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ See [Logback filters](https://logback.qos.ch/manual/filters.html#thresholdFilter
     <!-- Optional: defaults to the default credentials of the environment -->
     <credentialsFile>/path/to/credentials/file</credentialsFile>
 
+    <!-- Optional: defaults to the projectId specified in the environment or credentials -->
+    <projectId>project-id</projectId>
+
     <!-- Optional: add custom labels to log entries using LoggingEnhancer classes -->
     <enhancer>com.example.enhancers.TestLoggingEnhancer</enhancer>
     <enhancer>com.example.enhancers.AnotherEnhancer</enhancer>

--- a/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
+++ b/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
@@ -71,6 +71,9 @@ import java.util.Set;
  *         &lt;!-- Optional: defaults to the default credentials of the environment --&gt;
  *         &lt;credentialsFile&gt;/path/to/credentials/file&lt;/credentialsFile&gt;
  *
+ *         &lt;!-- Optional: defaults to the projectId specified in the environment or credentials --&gt;
+ *         &lt;projectId&gt;project-id&lt;/projectId&gt;
+ *
  *         &lt;!-- Optional: add custom labels to log entries using {@link LoggingEnhancer} classes --&gt;
  *         &lt;enhancer&gt;com.example.enhancers.TestLoggingEnhancer&lt/enhancer&gt;
  *         &lt;enhancer&gt;com.example.enhancers.AnotherEnhancer&lt/enhancer&gt;

--- a/src/test/java/com/google/cloud/logging/logback/LoggingAppenderTest.java
+++ b/src/test/java/com/google/cloud/logging/logback/LoggingAppenderTest.java
@@ -271,6 +271,11 @@ public class LoggingAppenderTest {
       LoggingOptions options = appender.getLoggingOptions();
       assertThat(options).isEqualTo(defaultOptions);
     }
+    // Try to build LoggingOptions with projectId.
+    appender = new LoggingAppender();
+    appender.setProjectId("project-id");
+    LoggingOptions options = appender.getLoggingOptions();
+    assertThat(options.getProjectId()).isEqualTo("project-id");
   }
 
   private LoggingEvent createLoggingEvent(Level level, long timestamp) {


### PR DESCRIPTION
This makes it possible to set the projectId via logging config instead of just by environment variable or the default project. While it is possible to override the projectId inherited from a service account via the `GOOGLE_CLOUD_PROJECT` environment variable, this is not always convenient. Being able to override the projectId along side other logging configuration keeps everything in one place.