### PR TITLE
chore: fix unit tests

### DIFF
--- a/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
+++ b/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
@@ -233,10 +233,8 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   }
 
   private void setupMonitoredResource() {
-    if (autoPopulateMetadata) {
+    if (monitoredResource == null && autoPopulateMetadata) {
       monitoredResource = MonitoredResourceUtil.getResource(getProjectId(), resourceType);
-    } else {
-      monitoredResource = null;
     }
   }
 


### PR DESCRIPTION
To support unit testing auto-population logic, the setup of the monitored resource should do nothing if the variable is set.