### PR TITLE
ci: try renaming tests for GraalVM native image test

### DIFF
--- a/src/test/java/com/google/cloud/logging/logback/ITMDCEventEnhancerTest.java
+++ b/src/test/java/com/google/cloud/logging/logback/ITMDCEventEnhancerTest.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MDCEventEnhancerTest {
+public class ITMDCEventEnhancerTest {
   private MDCEventEnhancer classUnderTest;
 
   @Before

--- a/src/test/java/com/google/cloud/logging/logback/ITStackTraceTest.java
+++ b/src/test/java/com/google/cloud/logging/logback/ITStackTraceTest.java
@@ -21,7 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import org.junit.Test;
 
-public class StackTraceTest {
+public class ITStackTraceTest {
   @Test
   public void testStack() {
     Exception ex = new UnsupportedOperationException("foo");

--- a/src/test/java/com/google/cloud/logging/logback/ITTraceLoggingEventEnhancerTest.java
+++ b/src/test/java/com/google/cloud/logging/logback/ITTraceLoggingEventEnhancerTest.java
@@ -25,7 +25,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class TraceLoggingEventEnhancerTest {
+public class ITTraceLoggingEventEnhancerTest {
   private TraceLoggingEventEnhancer classUnderTest;
 
   @Before


### PR DESCRIPTION
This PR runs certain tests that don't use mocks as part of Kokoro GraalVM native image test.

This PR is not intended to get merged.