### PR TITLE
feat: Add support for library instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ If you are using Maven, add this to your pom.xml file:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-logback</artifactId>
-  <version>0.125.2-alpha</version>
+  <version>0.125.3-alpha</version>
 </dependency>
 ```
 
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-logging-logback:0.125.2-alpha'
+implementation 'com.google.cloud:google-cloud-logging-logback:0.125.3-alpha'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging-logback" % "0.125.2-alpha"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging-logback" % "0.125.3-alpha"
 ```
 
 ## Authentication

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,10 @@
           </exclusion>
         </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>    
   </dependencies>
 
   <reporting>

--- a/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
+++ b/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
@@ -41,7 +41,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -321,17 +320,16 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
   @Override
   protected void append(ILoggingEvent e) {
-    Iterable<LogEntry> entries = Collections.singleton(logEntryFor(e));
+    List<LogEntry> entriesList = new ArrayList<LogEntry>();
+    entriesList.add(logEntryFor(e));
     // Check if instrumentation was already added - if not, create a log entry with instrumentation
     // data
     if (!setInstrumentationStatus(true)) {
-      List<LogEntry> result = new ArrayList<LogEntry>();
-      entries.forEach(result::add);
-      result.add(
+      entriesList.add(
           Instrumentation.createDiagnosticEntry(
               JAVA_LOGBACK_LIBRARY_NAME, Instrumentation.getLibraryVersion(LoggingAppender.class)));
-      entries = result;
     }
+    Iterable<LogEntry> entries = entriesList;
     if (autoPopulateMetadata) {
       entries =
           getLogging()

--- a/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
+++ b/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
@@ -25,6 +25,7 @@ import ch.qos.logback.core.util.Loader;
 import com.google.api.core.InternalApi;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.MonitoredResource;
+import com.google.cloud.logging.Instrumentation;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.Logging.WriteOption;
@@ -100,6 +101,9 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
       "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent";
   private static final List<LoggingEventEnhancer> DEFAULT_LOGGING_EVENT_ENHANCERS =
       ImmutableList.<LoggingEventEnhancer>of(new MDCEventEnhancer());
+  public static final String JAVA_LOGBACK_LIBRARY_NAME = "java-logback";
+  private static boolean instrumentationAdded = false;
+  private static Object instrumentationLock = new Object();
 
   private volatile Logging logging;
   private LoggingOptions loggingOptions;
@@ -318,6 +322,16 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   @Override
   protected void append(ILoggingEvent e) {
     Iterable<LogEntry> entries = Collections.singleton(logEntryFor(e));
+    // Check if instrumentation was already added - if not, create a log entry with instrumentation
+    // data
+    if (!setInstrumentationStatus(true)) {
+      List<LogEntry> result = new ArrayList<LogEntry>();
+      entries.forEach(result::add);
+      result.add(
+          Instrumentation.createDiagnosticEntry(
+              JAVA_LOGBACK_LIBRARY_NAME, Instrumentation.getLibraryVersion(LoggingAppender.class)));
+      entries = result;
+    }
     if (autoPopulateMetadata) {
       entries =
           getLogging()
@@ -488,6 +502,21 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         return Severity.ERROR;
       default:
         return Severity.DEFAULT;
+    }
+  }
+
+  /**
+   * The package-private helper method used to set the flag which indicates if instrumentation info
+   * already written or not.
+   *
+   * @returns The value of the flag before it was set.
+   */
+  static boolean setInstrumentationStatus(boolean value) {
+    if (instrumentationAdded == value) return instrumentationAdded;
+    synchronized (instrumentationLock) {
+      boolean current = instrumentationAdded;
+      instrumentationAdded = value;
+      return current;
     }
   }
 }


### PR DESCRIPTION
This feature provides an ability to log extra entry with diagnostics structure which contains logging library information. Such entry is logged only once when first entry is written by a process using logging library.

Fixes #[<788>](https://github.com/googleapis/java-logging-logback/issues/788) ☕️

