### PR TITLE
fix: Add a partner team as approvers for PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 # The @googleapis/api-logging is the default owner for changes in this repo
-*                       @googleapis/yoshi-java @googleapis/api-logging
-**/*.java               @googleapis/api-logging
+*                       @googleapis/yoshi-java @googleapis/api-logging @googleapis/api-logging-partners
+**/*.java               @googleapis/api-logging @googleapis/api-logging-partners
 
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -40,3 +40,5 @@ permissionRules:
     permission: admin
   - team: yoshi-java
     permission: push
+  - team: api-logging-partners
+    permission: push    


### PR DESCRIPTION
Adding @googleapis/api-logging-partners to contain more people who can approve PRs

