### PR TITLE
chore: clean up final keyword and javaDoc typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ If you are using Maven, add this to your pom.xml file:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-logback</artifactId>
-  <version>0.129.7-alpha</version>
+  <version>0.129.8-alpha</version>
 </dependency>
 ```
 
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-logging-logback:0.129.7-alpha'
+implementation 'com.google.cloud:google-cloud-logging-logback:0.129.8-alpha'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging-logback" % "0.129.7-alpha"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging-logback" % "0.129.8-alpha"
 ```
 
 ## Authentication

--- a/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
+++ b/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
@@ -248,8 +248,7 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   /**
    * Returns the current value of the ingestion mode.
    *
-   * <p>The method is deprecated.
-   * Use appender configuration to set up the ingestion
+   * <p>The method is deprecated. Use appender configuration to set up the ingestion
    *
    * @return a {@link Synchronicity} value of the ingestion module.
    */

--- a/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
+++ b/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
@@ -102,7 +102,7 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   private static final String TYPE =
       "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent";
   private static final List<LoggingEventEnhancer> DEFAULT_LOGGING_EVENT_ENHANCERS =
-      ImmutableList.<LoggingEventEnhancer>of(new MDCEventEnhancer());
+      ImmutableList.of(new MDCEventEnhancer());
   public static final String JAVA_LOGBACK_LIBRARY_NAME = "java-logback";
   // Using release-please annotations to update DEFAULT_INSTRUMENTATION_VERSION with latest version.
   // See
@@ -111,7 +111,7 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   public static final String DEFAULT_INSTRUMENTATION_VERSION = "0.129.9-alpha-SNAPSHOT";
   // {x-version-update-end}
   private static boolean instrumentationAdded = false;
-  private static Object instrumentationLock = new Object();
+  private static final Object instrumentationLock = new Object();
 
   private volatile Logging logging;
   private LoggingOptions loggingOptions;
@@ -158,7 +158,7 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
    * Sets the name of the monitored resource (Optional). If not define the appender will try to
    * identify the resource type automatically. Currently support resource types include "gae_app",
    * "gce_instance", "k8s_container", "cloud_run_revision" and "cloud_function". If the appender
-   * fails to identify the resource type it will be set to "global".
+   * fails to identify the resource type, it will be set to "global".
    *
    * <p>Must be a one of the <a href=
    * "https://cloud.google.com/logging/docs/api/v2/resource-list">supported</a> resource types.
@@ -248,7 +248,8 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   /**
    * Returns the current value of the ingestion mode.
    *
-   * <p>The method is deprecated. Use appender configuration to setup the ingestion
+   * <p>The method is deprecated.
+   * Use appender configuration to set up the ingestion
    *
    * @return a {@link Synchronicity} value of the ingestion module.
    */
@@ -344,7 +345,7 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
   @Override
   protected void append(ILoggingEvent e) {
-    List<LogEntry> entriesList = new ArrayList<LogEntry>();
+    List<LogEntry> entriesList = new ArrayList<>();
     entriesList.add(logEntryFor(e));
     // Check if instrumentation was already added - if not, create a log entry with instrumentation
     // data
@@ -531,7 +532,7 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
    * The package-private helper method used to set the flag which indicates if instrumentation info
    * already written or not.
    *
-   * @returns The value of the flag before it was set.
+   * @return The value of the flag before it was set.
    */
   static boolean setInstrumentationStatus(boolean value) {
     if (instrumentationAdded == value) return instrumentationAdded;

--- a/src/main/java/com/google/cloud/logging/logback/MDCEventEnhancer.java
+++ b/src/main/java/com/google/cloud/logging/logback/MDCEventEnhancer.java
@@ -30,7 +30,7 @@ import java.util.Map;
 final class MDCEventEnhancer implements LoggingEventEnhancer {
 
   @Override
-  public final void enhanceLogEntry(LogEntry.Builder builder, ILoggingEvent e) {
+  public void enhanceLogEntry(LogEntry.Builder builder, ILoggingEvent e) {
     for (Map.Entry<String, String> entry : e.getMDCPropertyMap().entrySet()) {
       if (null != entry.getKey() && null != entry.getValue()) {
         builder.addLabel(entry.getKey(), entry.getValue());

--- a/src/test/java/com/google/cloud/logging/logback/LoggingAppenderTest.java
+++ b/src/test/java/com/google/cloud/logging/logback/LoggingAppenderTest.java
@@ -63,9 +63,9 @@ public class LoggingAppenderTest {
   private static final String OVERRIDED_PROJECT_ID = "some-project-id";
   private static final String DUMMY_CRED_FILE_PATH =
       "src/test/java/com/google/cloud/logging/logback/dummy-credentials.json";
-  private static Payload.JsonPayload JSON_PAYLOAD =
+  private static final Payload.JsonPayload JSON_PAYLOAD =
       Payload.JsonPayload.of(ImmutableMap.of("message", "this is a test"));
-  private static Payload.JsonPayload JSON_ERROR_PAYLOAD =
+  private static final Payload.JsonPayload JSON_ERROR_PAYLOAD =
       Payload.JsonPayload.of(
           ImmutableMap.of(
               "message",


### PR DESCRIPTION
There are some changes that are not related to the functionality.

1. final keyword does not seem to be used consistently in test code.
2. final keyword is not required in the method of final class, so removed it.
3. Fixed some typos in javaDoc.