### PR TITLE
fix: update cloud-java-team as CODEOWNERS for delegated client release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # The @googleapis/api-logging is the default owner for changes in this repo
 *                       @googleapis/yoshi-java @googleapis/api-logging @googleapis/api-logging-partners
-**/*.java               @googleapis/api-logging @googleapis/api-logging-partners
+**/*.java               @googleapis/api-logging @googleapis/api-logging-partners @googleapis/cloud-java-team-teamsync
 
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers


### PR DESCRIPTION
Adding @googleapis/cloud-java-team-teamsync to CODEOWNERS for delegated client library release management.