### PR TITLE
deps: update google-cloud-logging to v3.15.5, google-cloud-shared-dependencies to v3.12.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,20 @@ If you are using Maven, add this to your pom.xml file:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-logback</artifactId>
-  <version>0.130.15-alpha</version>
+  <version>0.130.16-alpha</version>
 </dependency>
 ```
 
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-logging-logback:0.130.15-alpha'
+implementation 'com.google.cloud:google-cloud-logging-logback:0.130.16-alpha'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging-logback" % "0.130.15-alpha"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging-logback" % "0.130.16-alpha"
 ```
 <!-- {x-version-update-end} -->
 
@@ -299,7 +299,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-logging-logback/java11.html
 [stability-image]: https://img.shields.io/badge/stability-preview-yellow
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-logging-logback.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging-logback/0.130.15-alpha
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging-logback/0.130.16-alpha
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,7 @@
     <logback.version>1.2.11</logback.version>
     <easymock.version>5.1.0</easymock.version>
     <truth.version>1.1.5</truth.version>
-    <logging.version>3.15.1</logging.version>
-    <logging.version>3.15.4</logging.version>
+    <logging.version>3.15.5</logging.version>
     <slf4j.version>1.7.36</slf4j.version>
     <google.api-common.version>1.10.1</google.api-common.version>
   </properties>
@@ -66,7 +65,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.11.0</version>
+        <version>3.12.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Update these 2 dependencies together for dependency check to work together.
Closes #1119, #1117