### PR TITLE
deps: update dependency google-cloud-logging and sdk-platform-java-config

### DIFF
--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -14,6 +14,6 @@ jobs:
       shell: bash
       run: .kokoro/build.sh
     - name: Unmanaged dependency check
-      uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v3.36.1
+      uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v3.37.0
       with:
         bom-path: pom.xml

--- a/.kokoro/presubmit/graalvm-native-17.cfg
+++ b/.kokoro/presubmit/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.36.1"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.37.0"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.36.1"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.37.0"
 }
 
 env_vars: {

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <logback.version>1.2.13</logback.version>
     <easymock.version>5.4.0</easymock.version>
     <truth.version>1.4.4</truth.version>
-    <logging.version>3.20.3</logging.version>
+    <logging.version>3.20.4</logging.version>
     <slf4j.version>1.7.36</slf4j.version>
     <google.api-common.version>1.10.1</google.api-common.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>sdk-platform-java-config</artifactId>
-    <version>3.36.1</version>
+    <version>3.37.0</version>
   </parent>
 
   <developers>


### PR DESCRIPTION
manual combine changes to avoid enforcer failures.
closes #1381
closes #1382
BEGIN_COMMIT_OVERRIDE
deps: update dependency com.google.cloud:google-cloud-logging to v3.20.4
deps: update dependency com.google.cloud:sdk-platform-java-config to v3.37.0
END_COMMIT_OVERRIDE