### PR TITLE
feat: introduce `java.time`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
     <dependency>
       <groupId>org.threeten</groupId>
       <artifactId>threetenbp</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -229,13 +229,24 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredDependencies>
+            <!--We ignore threeten because its usage has been migrated to java.time and there are no public methods-->
+            <!--exposing this class-->
+            <ignoredDependency>org.threeten:threetenbp</ignoredDependency>
+          </ignoredDependencies>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
-      <profiles>
+  <profiles>
     <profile>
       <id>native</id>
       <properties>
-      <!-- Skip native image tests that use mocking libs to avoid loading classes at runtime. -->
+        <!-- Skip native image tests that use mocking libs to avoid loading classes at runtime. -->
         <test>!LoggingAppenderTest</test>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -152,11 +152,6 @@
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.threeten</groupId>
-      <artifactId>threetenbp</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,11 @@
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.threeten</groupId>
+      <artifactId>threetenbp</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <reporting>
@@ -229,24 +234,13 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <ignoredDependencies>
-            <!--We ignore threeten because its usage has been migrated to java.time and there are no public methods-->
-            <!--exposing this class-->
-            <ignoredDependency>org.threeten:threetenbp</ignoredDependency>
-          </ignoredDependencies>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
-  <profiles>
+      <profiles>
     <profile>
       <id>native</id>
       <properties>
-        <!-- Skip native image tests that use mocking libs to avoid loading classes at runtime. -->
+      <!-- Skip native image tests that use mocking libs to avoid loading classes at runtime. -->
         <test>!LoggingAppenderTest</test>
       </properties>
     </profile>

--- a/src/main/java/com/google/cloud/logging/logback/LogbackBatchingSettings.java
+++ b/src/main/java/com/google/cloud/logging/logback/LogbackBatchingSettings.java
@@ -19,7 +19,7 @@ package com.google.cloud.logging.logback;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController.LimitExceededBehavior;
-import org.threeten.bp.Duration;
+import java.time.Duration;
 
 /**
  * This class is used only to provide batch settings configuration in logback.xml since {@link
@@ -69,7 +69,7 @@ public class LogbackBatchingSettings {
       settings.setRequestByteThreshold(requestByteThreshold);
     }
     if (delayThreshold != null) {
-      settings.setDelayThreshold(Duration.ofMillis(delayThreshold));
+      settings.setDelayThresholdDuration(Duration.ofMillis(delayThreshold));
     }
     if (maxOutstandingElementCount != null
         || maxOutstandingRequestBytes != null


### PR DESCRIPTION
This PR introduces `java.time` alternatives to existing `org.threeten.bp.*` methods, as well as switching internal variables (if any) to `java.time`

The main constraint is to keep the changes backwards compatible, so for each existing threeten method "`method1(org.threeten.bp.Duration)`" we will add an alternative with a _Duration_ (or _Timestamp_ when applicable) suffix: "`method1Duration(java.time.Duration)`".

For most cases, the implementation will be held in the `java.time` method and the old threeten method will just delegate the call to it. However, for the case of abstract classes, the implementation will be kept in the threeten method to avoid breaking changes (i.e. users that already overloaded the method in their user code).