### PR TITLE
Fix: Fix Appender default flushlevel to be consistent with java-logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ See [Logback filters](https://logback.qos.ch/manual/filters.html#thresholdFilter
     <!-- Optional: defaults to "java.log" -->
     <log>application.log</log>
 
-    <!-- Optional: defaults to "ERROR" -->
+    <!-- Optional: defaults to "OFF" -->
     <flushLevel>WARN</flushLevel>
 
     <!-- Optional: defaults to ASYNC -->

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -13,7 +13,7 @@
 
   <!--
     The parent pom defines common style checks and testing strategies for our samples.
-    Removing or replacing it should not affect the execution of the samples in anyway.
+    Removing or replacing it should not affect the execution of the samples in any way.
   -->
   <parent>
     <groupId>com.google.cloud.samples</groupId>

--- a/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
+++ b/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java
@@ -62,7 +62,7 @@ import java.util.Set;
  *         &lt;!-- Optional: defaults to {@code "java.log"} --&gt;
  *         &lt;log&gt;application.log&lt;/log&gt;
  *
- *         &lt;!-- Optional: defaults to {@code "ERROR"} --&gt;
+ *         &lt;!-- Optional: defaults to {@code "OFF"} --&gt;
  *         &lt;flushLevel&gt;WARN&lt;/flushLevel&gt;
  *
  *         &lt;!-- Optional: defaults to {@code ASYNC} --&gt;
@@ -150,7 +150,7 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   /**
    * Sets a threshold for log severity level to flush all log entries that were batched so far.
    *
-   * <p>Defaults to Error.
+   * <p>Defaults to OFF.
    *
    * @param flushLevel Logback log level
    */
@@ -298,7 +298,7 @@ public class LoggingAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   }
 
   private Level getFlushLevel() {
-    return (flushLevel != null) ? flushLevel : Level.ERROR;
+    return (flushLevel != null) ? flushLevel : Level.OFF;
   }
 
   private String getLogName() {

--- a/src/test/java/com/google/cloud/logging/logback/LoggingAppenderTest.java
+++ b/src/test/java/com/google/cloud/logging/logback/LoggingAppenderTest.java
@@ -194,6 +194,13 @@ public class LoggingAppenderTest {
   }
 
   @Test
+  public void testDefaultFlushLevelOff() {
+    loggingAppender.start();
+    Severity foundSeverity = logging.getFlushSeverity();
+    assertThat(foundSeverity).isEqualTo(null);
+  }
+
+  @Test
   public void testFilterLogsOnlyLogsAtOrAboveLogLevel() {
     logging.setFlushSeverity(Severity.ERROR);
     Capture<Iterable<LogEntry>> capturedArgument = Capture.newInstance();

--- a/src/test/java/com/google/cloud/logging/logback/LoggingAppenderTest.java
+++ b/src/test/java/com/google/cloud/logging/logback/LoggingAppenderTest.java
@@ -202,7 +202,6 @@ public class LoggingAppenderTest {
 
   @Test
   public void testFilterLogsOnlyLogsAtOrAboveLogLevel() {
-    logging.setFlushSeverity(Severity.ERROR);
     Capture<Iterable<LogEntry>> capturedArgument = Capture.newInstance();
     logging.write(
         capture(capturedArgument),
@@ -230,7 +229,6 @@ public class LoggingAppenderTest {
 
   @Test
   public void testPartialSuccessOverrideHasExpectedValue() {
-    logging.setFlushSeverity(Severity.ERROR);
     Capture<WriteOption> logNameArg = Capture.newInstance();
     Capture<WriteOption> resourceArg = Capture.newInstance();
     Capture<WriteOption> partialSuccessArg = Capture.newInstance();
@@ -254,7 +252,6 @@ public class LoggingAppenderTest {
 
   @Test
   public void testDefaultWriteOptionsHasExpectedDefaults() {
-    logging.setFlushSeverity(Severity.ERROR);
     Capture<WriteOption> partialSuccessArg = Capture.newInstance();
     logging.write(
         EasyMock.<Iterable<LogEntry>>anyObject(),
@@ -273,7 +270,6 @@ public class LoggingAppenderTest {
 
   @Test
   public void testMdcValuesAreConvertedToLabels() {
-    logging.setFlushSeverity(Severity.ERROR);
     Capture<Iterable<LogEntry>> capturedArgument = Capture.newInstance();
     logging.write(
         capture(capturedArgument),
@@ -332,7 +328,6 @@ public class LoggingAppenderTest {
     MDC.put("mdc1", "value1");
     MDC.put("mdc2", null);
     MDC.put("mdc3", "value3");
-    logging.setFlushSeverity(Severity.ERROR);
     Capture<Iterable<LogEntry>> capturedArgument = Capture.newInstance();
     logging.write(
         capture(capturedArgument),
@@ -358,7 +353,6 @@ public class LoggingAppenderTest {
   @Test
   public void testAddCustomLoggingEventEnhancers() {
     MDC.put("mdc1", "value1");
-    logging.setFlushSeverity(Severity.ERROR);
     Capture<Iterable<LogEntry>> capturedArgument = Capture.newInstance();
     logging.write(
         capture(capturedArgument),
@@ -382,7 +376,6 @@ public class LoggingAppenderTest {
 
   @Test
   public void testAddCustomLoggingEnhancer() {
-    logging.setFlushSeverity(Severity.ERROR);
     Capture<Iterable<LogEntry>> capturedArgument = Capture.newInstance();
     logging.write(
         capture(capturedArgument),
@@ -405,7 +398,6 @@ public class LoggingAppenderTest {
   @Test
   @SuppressWarnings("deprecation")
   public void testFlush() {
-    logging.setFlushSeverity(Severity.ERROR);
     logging.write(
         EasyMock.<Iterable<LogEntry>>anyObject(),
         anyObject(WriteOption.class),
@@ -426,7 +418,6 @@ public class LoggingAppenderTest {
 
   @Test
   public void testAutoPopulationEnabled() {
-    logging.setFlushSeverity(Severity.ERROR);
     Capture<Iterable<LogEntry>> capturedLogEntries = Capture.newInstance();
     EasyMock.expect(
             logging.populateMetadata(
@@ -465,7 +456,6 @@ public class LoggingAppenderTest {
 
   @Test
   public void testRedirectToStdoutEnabled() {
-    logging.setFlushSeverity(Severity.ERROR);
     EasyMock.expect(
             logging.populateMetadata(
                 EasyMock.<Iterable<LogEntry>>anyObject(),
@@ -510,7 +500,6 @@ public class LoggingAppenderTest {
   public void testFDiagnosticInfoAdded() {
     LoggingAppender.setInstrumentationStatus(false);
     Capture<Iterable<LogEntry>> capturedArgument = Capture.newInstance();
-    logging.setFlushSeverity(Severity.ERROR);
     logging.write(
         capture(capturedArgument),
         anyObject(WriteOption.class),
@@ -554,7 +543,6 @@ public class LoggingAppenderTest {
 
   @Test
   public void testFDiagnosticInfoNotAdded() {
-    logging.setFlushSeverity(Severity.ERROR);
     Capture<Iterable<LogEntry>> capturedArgument = Capture.newInstance();
     logging.write(
         capture(capturedArgument),

--- a/src/test/java/com/google/cloud/logging/logback/logback.xml
+++ b/src/test/java/com/google/cloud/logging/logback/logback.xml
@@ -8,7 +8,7 @@
     <!-- Optional: defaults to "java.log" -->
     <log>application.log</log>
 
-    <!-- Optional: defaults to "ERROR" -->
+    <!-- Optional: defaults to "OFF" -->
     <flushLevel>WARN</flushLevel>
 
     <!-- Optional: defaults to ASYNC -->


### PR DESCRIPTION
The java-logging library defaults to logging flush level to be OFF due to the performance cost of flushing on the same thread as the application. This fix is to change appender default flush level from `error` to be `off` to be consistent with java-logging library. For testing, added unit tests and changed existing easymock testing expectations.

Fixes #1328  ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
