### PR TITLE
chore: Remove PR rate limit in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 0,
-  "prHourlyLimit": 0
+  "prHourlyLimit": 0,
   "extends": [
     ":separateMajorReleases",
     ":combinePatchMinorReleases",


### PR DESCRIPTION
We are seeing renovate bot being rate limited in https://github.com/googleapis/java-logging-logback/issues/167. Remove PR rate limit in renovate.json per https://docs.renovatebot.com/presets-default/#prconcurrentlimitnone.